### PR TITLE
Update Styleguide to make it compatible with Yarn3 setup

### DIFF
--- a/lib/capistrano/tasks/styleguide.rake
+++ b/lib/capistrano/tasks/styleguide.rake
@@ -12,10 +12,10 @@ namespace :styleguide do
   desc "Build assets locally from current repo"
   task :build_local do
     run_locally do
-      execute 'yarn', '--check-files', '--no-progress', '--silent'
+      execute 'yarn', '--silent'
 
       # Build the styleguide localy
-      execute 'yarn', 'build', '--production'
+      execute 'yarn', 'build'
     end
   end
 
@@ -29,7 +29,7 @@ namespace :styleguide do
 
       # Retrieve styleguide from npm
       # execute 'npm', '--no-spin', '--silent', 'install'
-      execute 'yarn', 'install', '--check-files', '--no-progress', '--silent'
+      execute 'yarn', 'install', '--silent'
 
       # Build the styleguide localy
       execute './node_modules/.bin/gulp', 'build', '--production'


### PR DESCRIPTION
### 💬 Describe the pull request/code changes
On recent project, we use yarn v3 and the API changed a bit.

I got the following errors on deployment:

```
$ yarn install --check-files --no-progress --silent
Unknown Syntax Error: Unsupported option name ("--check-files").
```

```
[webpack-cli] Error: Unknown option '--production'
```

I'm still not sure if this is really backward compatible...