### PR TITLE
File.exists -> File.exists

### DIFF
--- a/lib/capistrano/antistatique/drupal/bootstrap.rb
+++ b/lib/capistrano/antistatique/drupal/bootstrap.rb
@@ -26,7 +26,7 @@ namespace :deploy do
       ask(:site_name, "Site name")
 
       on roles(:app) do
-        if File.exists?(current_path) && !File.symlink?(current_path)
+        if File.exist?(current_path) && !File.symlink?(current_path)
           info "Recursively delete the current directory #{current_path} to prevent fail on symlink creation."
           execute :rm, '-rf', current_path
         end

--- a/lib/capistrano/tasks/styleguide.rake
+++ b/lib/capistrano/tasks/styleguide.rake
@@ -23,7 +23,7 @@ namespace :styleguide do
   task :build_from_npm do
     run_locally do
       # Delete existing styleguide
-      if File.exists?(fetch(:styleguide_path))
+      if File.exist?(fetch(:styleguide_path))
         FileUtils.rm_rf(fetch(:styleguide_path))
       end
 
@@ -40,7 +40,7 @@ namespace :styleguide do
   task :build_from_git do
     run_locally do
       # Delete existing styleguide
-      if File.exists?(fetch(:styleguide_path))
+      if File.exist?(fetch(:styleguide_path))
         FileUtils.rm_rf(fetch(:styleguide_path))
       end
 
@@ -49,7 +49,7 @@ namespace :styleguide do
       execute 'yarn', 'install', '--no-progress', '--silent'
 
       # Delete existing styleguide downloaded by npm
-      if File.exists?(fetch(:styleguide_path))
+      if File.exist?(fetch(:styleguide_path))
         FileUtils.rm_rf(fetch(:styleguide_path))
       end
 


### PR DESCRIPTION
I don't know how I ended to have Ruby 3.x installed on my machine but when I tried to deploy a project I encountered this error:

```
NoMethodError: undefined method `exists?' for File:Class
/project/config/capistrano/tasks/styleguide.rake:7:in `block (3 levels) in <top (required)>'
/project/config/capistrano/tasks/styleguide.rake:5:in `block (2 levels) in <top (required)>'
Tasks: TOP => styleguide:upload_build => styleguide:git_clone_local
```

Found out that `File.exists?` were deprecated and removed in Ruby v3: https://ruby-doc.org/core-3.0.0/File.html#method-c-exist-3F