### PR TITLE
[codex] Add WordPress translation sync tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ bundle exec cap staging wordpress:i18n:download
 bundle exec cap staging wordpress:i18n:upload
 ```
 
-By default, translation files are synced from `#{fetch(:app_path)}/app/languages/`. Override that in `config/deploy.rb` if your project uses another directory:
+By default, `wordpress_languages_path` is set to `app/languages`, so the tasks sync `#{fetch(:app_path)}/#{fetch(:wordpress_languages_path)}/`. Override that in `config/deploy.rb` if your project uses another directory relative to `app_path`:
 
 ```ruby
-set :wordpress_languages_path, 'web/app/languages'
+set :wordpress_languages_path, 'app/languages'
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -96,6 +96,21 @@ Dir.glob('config/capistrano/tasks/*.rake').each { |r| import r }
 
 Then, go to `config/deploy.rb`, `config/deploy/staging.rb`, `conconfig/deploy/production.rb` to set the parameters of your project.
 
+### WordPress translation sync
+
+The shared WordPress tasks include translation file sync commands:
+
+```shell
+bundle exec cap staging wordpress:i18n:download
+bundle exec cap staging wordpress:i18n:upload
+```
+
+By default, translation files are synced from `#{fetch(:app_path)}/app/languages/`. Override that in `config/deploy.rb` if your project uses another directory:
+
+```ruby
+set :wordpress_languages_path, 'web/app/languages'
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/capistrano/tasks/wordpress.rake
+++ b/lib/capistrano/tasks/wordpress.rake
@@ -1,4 +1,10 @@
 namespace :wordpress do
+  namespace :load do
+    task :defaults do
+      set :wordpress_languages_path, 'app/languages'
+    end
+  end
+
  
   desc "Install WP cli"
   task :install_executable do
@@ -96,6 +102,46 @@ namespace :wordpress do
             local_files_dir = "#{(fetch(:app_path))}/app/uploads/"
             system("rsync --recursive --times --rsh=ssh --human-readable --progress #{server.user}@#{server.hostname}:#{remote_files_dir} #{local_files_dir}")
           end
+        end
+      end
+    end
+  end
+
+  namespace :i18n do
+    desc "Download WordPress translation files from the remote server"
+    task :download do
+      run_locally do
+        on release_roles :app do |server|
+          ask(:answer, 'Do you really want to download translation files from the remote server to your local machine? Existing files may be overwritten. (y/N)')
+          next unless fetch(:answer) == 'y'
+
+          languages_path = fetch(:wordpress_languages_path).gsub(%r{^/|/$}, '')
+          remote_files_dir = "#{shared_path}/#{fetch(:app_path)}/#{languages_path}/"
+          local_files_dir = "#{fetch(:app_path)}/#{languages_path}/"
+
+          info local_files_dir
+          info remote_files_dir
+
+          system("rsync -v --recursive --times --rsh=ssh --human-readable --progress --exclude='.*' --exclude='.po~' --exclude='.mo~' #{server.user}@#{server.hostname}:#{remote_files_dir} #{local_files_dir}")
+        end
+      end
+    end
+
+    desc "Upload WordPress translation files from the local machine"
+    task :upload do
+      run_locally do
+        on release_roles :app do |server|
+          ask(:answer, 'Do you really want to upload translation files from your local machine to the remote server? Remote files will be overwritten. (y/N)')
+          next unless fetch(:answer) == 'y'
+
+          languages_path = fetch(:wordpress_languages_path).gsub(%r{^/|/$}, '')
+          remote_files_dir = "#{shared_path}/#{fetch(:app_path)}/#{languages_path}/"
+          local_files_dir = "#{fetch(:app_path)}/#{languages_path}/"
+
+          info local_files_dir
+          info remote_files_dir
+
+          system("rsync -v --recursive --times --rsh=ssh --human-readable --progress --exclude='.*' --exclude='.po~' --exclude='.mo~' #{local_files_dir} #{server.user}@#{server.hostname}:#{remote_files_dir}")
         end
       end
     end


### PR DESCRIPTION
## What changed
- add shared `wordpress:i18n:download` and `wordpress:i18n:upload` Capistrano tasks
- add the `wordpress_languages_path` setting with a default of `app/languages`
- document the new WordPress translation sync commands in the README

## Why
These translation sync recipes were living in a single project and needed to be shared across other WordPress projects using this gem.

## Impact
WordPress projects can now reuse the same translation file upload and download workflow without copying custom deployment recipes.

## Validation
- `ruby -c lib/capistrano/tasks/wordpress.rake`
